### PR TITLE
Kubernetes networks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # xom4ek_platform
+
 xom4ek Platform repository
 
 ## Краткое описание
@@ -8,6 +9,7 @@ xom4ek Platform repository
 ### 1. Kubernetes-intro
 
 #### Задания:
+
 - Разобрать механизм запуска подов в namespace kube-system при использовании kubeadm
 - Написать Dockerfile и собрать image с вебсервером
 - Написать манифест для запуска контейнера в Pod'e
@@ -43,3 +45,51 @@ xom4ek Platform repository
 - [Node-exporter](https://github.com/prometheus/node_exporter)
 - [Taints and Toleration](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#concepts)
 - [Описание выполненного ДЗ](kubernetes-controllers/README.md)
+
+### 3. Kubernetes-security
+
+#### Задания:
+
+##### task01
+- Создать Service Account bob, дать ему роль admin в рамках всего кластера
+- Создать Service Account dave без доступа к кластеру
+
+###### taks02
+- Создать Namespace prometheus
+- Создать Service Account carol в этом Namespace
+- Дать всем Service Account в Namespace prometheus возможность делать get, list, watch в отношении Pods всего кластера
+
+###### task03
+- Создать Namespace dev
+- Создать Service Account jane в Namespace dev
+- Дать jane роль admin в рамках Namespace dev
+- Создать Service Account ken в Namespace dev
+- Дать ken роль view в рамках Namespace dev
+
+#### Полезные ссылки
+
+- [ServiceAccountsForPods](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
+- [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [kubectl auth can-i](https://kubernetes.io/docs/reference/access-authn-authz/authorization/)
+- [Описание выполненного ДЗ](kubernetes-security/README.md)
+
+### 4. Kubernetes-networks
+
+#### Задания:
+- Добавлены и изучены механизмы liveness и readiness probe
+- Добавлены и изучены механизмы liveness и readiness probe
+- Создали несколько типов services
+- Установлен MetalLB / Ingress / законфигурирован minikube длля использования IPVS
+- :star: Сделан сервис LoadBalancer , который откроет доступ к CoreDNS снаружи кластера
+- Создан service с внешним IP выданным MetalLB для использования под ingress + headless services
+- :star: Создан ingress для kubernetes dashobard для доступа за /dashbaord
+- :star: Создан ingress с конфигурацией под канареечное развертывание
+
+#### Полезные ссылки
+- [svc and iptables](https://msazure.club/kubernetes-services-and-iptables/)
+- [ipvs k8s](https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/ipvs/README.md)
+- [strictARP issue](https://github.com/metallb/metallb/issues/153)
+- [Balancing types](https://github.com/kubernetes/kubernetes/blob/1cb3b5807ec37490b4582f22d991c043cc468195/pkg/proxy/apis/config/types.go) и [another](http://www.linuxvirtualserver.org/docs/scheduling.html)
+- [Metallb](https://metallb.universe.tf/)
+- [Ingress-nginx](https://kubernetes.github.io/ingress-nginx/deploy/)
+- [Описание выполненного ДЗ](kubernetes-networks/README.md)

--- a/cluster.kind.config
+++ b/cluster.kind.config
@@ -1,9 +1,0 @@
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-nodes:
-- role: control-plane
-- role: control-plane
-- role: control-plane
-- role: worker
-- role: worker
-- role: worker

--- a/kubernetes-networks/README.md
+++ b/kubernetes-networks/README.md
@@ -1,0 +1,162 @@
+# xom4ek_platform
+xom4ek Platform repository
+
+# Выполнено ДЗ №1
+
+- [x] Основное ДЗ
+- [x] Задание со *
+
+## В процессе сделано:
+
+- #### Добавлены и изучены механизмы liveness и readiness probe
+
+ Дополнительно они описанны по [ссылке](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+
+  ```yaml
+  readinessProbe:
+    httpGet:
+      path: /index.html
+      port: 8000
+  livenessProbe:
+    tcpSocket:
+      port: 8000
+  ```
+
+- #### Создали несколько [типов services](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
+
+  - [LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer)
+  - [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport)
+  - [ClusterIP](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
+  - [ExternalName](https://kubernetes.io/docs/concepts/services-networking/service/#externalname)
+
+  Дополнительно про endpoints можно почитать [тут](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/)
+
+- #### Установлен MetalLB / Ingress / законфигурирован minikube длля использования IPVS
+  - Настройка использования [IPVS]()
+  ```sh
+
+  ### move strictARP to true and mode to IPVS
+  kubectl get configmap kube-proxy -n kube-system -o yaml | \
+  sed -e 's/strictARP: false/strictARP: true/' | \
+  sed -e 's/mode: ""/mode: "ipvs"/' | \
+  kubectl apply -f - -n kube-system
+
+  ### recreate pods kube-proxy
+  kubectl --namespace kube-system delete pod --selector='k8s-app=kube-proxy'
+  ```
+
+  - Установка [MetalLB](https://metallb.universe.tf/installation/)
+  ```sh
+  export VERSION_MLB=v0.9.3
+  kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/$VERSION_MLB/manifests/namespace.yaml
+  kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/$VERSION_MLB/manifests/metallb.yaml
+  # On first install only
+  kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+  ```
+  - Установка [Nginx-ingress](https://kubernetes.github.io/ingress-nginx/deploy/#bare-metal)
+  ```sh
+  kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/baremetal/deploy.yaml
+  ```
+
+- #### :star: Сделан сервис LoadBalancer , который откроет доступ к CoreDNS снаружи кластера
+
+    Использование разных протоколов в одном service с типом [LoadBalancing запрещено](https://github.com/kubernetes/kubernetes/issues/23880) пока не реализовано, поэтому не получится использовать один service.
+    Необходимо использовать annotation MetalLB [metallb.universe.tf/allow-shared-ip](https://metallb.universe.tf/usage/#ip-address-sharing), что позволит двум Service с разными протоколами маршрутизироваться по одному внешнему IP.
+
+- #### Создан service с внешним IP выданным MetalLB для использования под ingress +  headless сервис
+
+  Service для Ingress
+  ```yaml
+  spec:
+    externalTrafficPolicy: Local
+    type: LoadBalancer
+    selector:
+      app.kubernetes.io/name: ingress-nginx
+  ```
+
+  Headless
+  ```yaml
+  type: ClusterIP
+  clusterIP: None
+  ```
+
+  Ну и пример правила для ingress
+
+  ```yaml
+  spec:
+    rules:
+    - http:
+        paths:
+        - path: /web
+          backend:
+            serviceName: web-svc
+            servicePort: 8000
+  ```
+
+  Дополнительно про spec можно почитать [тут](https://kubernetes.github.io/ingress-nginx/user-guide/basic-usage/)
+
+- #### :star: Создан ingress для kubernetes dashobard для доступа за /dashbaord
+
+    Были использованы стандартные [аннотации nginx-ingress](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/):
+    - [nginx.ingress.kubernetes.io/rewrite-target](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#rewrite)
+    - [nginx.ingress.kubernetes.io/backend-protocol](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#backend-protocol)
+    - [nginx.ingress.kubernetes.io/permanent-redirect](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#permanent-redirect)
+
+  Важный кусок
+  ```yaml
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+  ...
+  - path: /dashboard/(.*)
+  ```
+
+  B для того чтобы работало dashboard без /
+  ```yaml
+  annotations:
+    nginx.ingress.kubernetes.io/permanent-redirect: /dashboard/
+  ...
+  - path: /dashboard$
+  ```
+
+- #### :star: Создан ingress с конфигурацией под канареечное развертывание
+  Общее описание Canary для ingress-nginx [тут](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#canary)
+  Использовались anotations:
+  - nginx.ingress.kubernetes.io/canary
+  - nginx.ingress.kubernetes.io/canary-by-header
+  - nginx.ingress.kubernetes.io/canary-by-header-value
+
+  > Без конкретного hostname в ingress ничего не работало, хочется понять почему.
+
+## Как запустить проект:
+ ```shell
+git clone https://github.com/otus-kuber-2020-04/xom4ek_platform.git && \
+cd xom4ek_platform && \
+git checkout kubernetes-networks && \
+cd kubernetes-networks && prepare/install.sh
+ ```
+
+## Как проверить работоспособность:
+
+- :star: coredns:
+
+```shell
+nslookup kubernetes.default.svc.cluster.local 172.17.255.10
+```
+
+- :star: ingress for Dashboard:
+
+```shell
+curl -L $(kubectl get svc ingress-nginx -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')/dashboard
+```
+
+- :star: canary ingress
+
+```shell
+
+curl -s --resolve example.com:80:kubectl get svc ingress-nginx -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}' example.com:80/canary | grep -v '>'
+
+curl -s --resolve example.com:80:kubectl get svc ingress-nginx -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}' -H "canary:catch" example.com:80/canary | grep -v '>'
+```
+
+## PR checklist:
+- [x] Выставлен label с темой домашнего задания

--- a/kubernetes-networks/canary/cm.yaml
+++ b/kubernetes-networks/canary/cm.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bird
+data:
+  index.html: |
+    <body>
+    <html>
+    <pre>
+            .-"-.
+          /  - -\
+          \  @ @/
+            (_ <_)
+            _)(`
+        ,_(`_))\
+        "-\)__/
+          __|||__
+    jgs  ((__|__))
+    </pre>
+    </body>
+    </html>
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cat
+data:
+  index.html: |
+    <body>
+    <html>
+    <pre>
+                  / ,
+              /\  \|/  /\
+              |\\_;=._//|
+              \."   "./
+              //^\ /^\\
+        .'``",/ |0| |0| \,"``'.
+      /   ,  `'\.---./'`  ,   \
+      /`  /`\,."(     )".,/`\  `\
+      /`     ( '.'-.-'.' )     `\
+      /"`     "._  :  _."     `"\
+      `/.'`"=.,_``=``_,.="`'.\`
+    jgs          )   (
+    </pre>
+    </body>
+    </html>

--- a/kubernetes-networks/canary/ingress.yaml
+++ b/kubernetes-networks/canary/ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: tweety
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+
+spec:
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /canary
+            backend:
+              serviceName: tweety
+              servicePort: 8000
+
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: sylvester
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-by-header: "canary"
+    nginx.ingress.kubernetes.io/canary-by-header-value: "catch"
+spec:
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /canary
+            backend:
+              serviceName: sylvester
+              servicePort: 8000

--- a/kubernetes-networks/canary/pods.yaml
+++ b/kubernetes-networks/canary/pods.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tweety
+  labels:
+    app: tweety
+spec:
+  containers:
+    - name: tweety
+      image: registry.hub.docker.com/xom4ek/web:kubernetes-intro
+      resources: {}
+      readinessProbe:
+        httpGet:
+          path: /index.html
+          port: 8000
+      livenessProbe:
+        tcpSocket:
+          port: 8000
+      volumeMounts:
+      - name: app
+        mountPath: /app
+  volumes:
+  - name: app
+    configMap:
+        name: bird
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sylvester
+  labels:
+    app: sylvester
+spec:
+  containers:
+    - name: sylvester
+      image: registry.hub.docker.com/xom4ek/web:kubernetes-intro
+      resources: {}
+      readinessProbe:
+        httpGet:
+          path: /index.html
+          port: 8000
+      livenessProbe:
+        tcpSocket:
+          port: 8000
+      volumeMounts:
+      - name: app
+        mountPath: /app
+  volumes:
+  - name: app
+    configMap:
+        name: cat

--- a/kubernetes-networks/canary/services.yaml
+++ b/kubernetes-networks/canary/services.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sylvester
+spec:
+  selector:
+    app: sylvester
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tweety
+spec:
+  selector:
+    app: tweety
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/coredns/external-dns.yaml
+++ b/kubernetes-networks/coredns/external-dns.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ext-dns-tcp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "ext-dns"
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.10
+  ports:
+    - name: dns-tcp
+      protocol: TCP
+      port: 53
+      targetPort: 53
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ext-dns-udp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "ext-dns"
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.10
+  ports:
+    - name: dns-udp
+      protocol: UDP
+      port: 53
+      targetPort: 53

--- a/kubernetes-networks/dashboard/ingress.yaml
+++ b/kubernetes-networks/dashboard/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /dashboard/(.*)
+        backend:
+          serviceName: kubernetes-dashboard
+          servicePort: 443
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: kubernetes-dashboard-redirect
+  namespace: kubernetes-dashboard
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/permanent-redirect: /dashboard/
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /dashboard$
+        backend:
+          serviceName: kubernetes-dashboard
+          servicePort: 443

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - "172.17.255.1-172.17.255.255"

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,22 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  - name: https
+    port: 443
+    targetPort: https

--- a/kubernetes-networks/prepare/install.sh
+++ b/kubernetes-networks/prepare/install.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+kubectl get configmap kube-proxy -n kube-system -o yaml | \
+  sed -e 's/strictARP: false/strictARP: true/' | \
+  sed -e 's/mode: ""/mode: "ipvs"/' | \
+  kubectl apply -f - -n kube-system
+kubectl --namespace kube-system delete pod --selector='k8s-app=kube-proxy'
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
+kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+kubectl wait --for=condition=available --timeout=600s deployment controller -n metallb-system
+kubectl apply -f metallb-config.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/baremetal/deploy.yaml
+kubectl wait --for=condition=available --timeout=600s deployment ingress-nginx-controller -n ingress-nginx
+kubectl apply -f nginx-lb.yaml
+kubectl apply -f web-deploy.yaml
+kubectl apply -f web-svc-cip.yaml
+kubectl apply -f web-svc-lb.yaml
+kubectl apply -f web-svc-headless.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.3/aio/deploy/recommended.yaml
+kubectl wait --for=condition=available --timeout=600s deployment kubernetes-dashboard -n kubernetes-dashboard
+kubectl apply -f web-ingress.yaml
+kubectl apply -f coredns/external-dns.yaml
+kubectl apply -f dashboard/ingress.yaml
+kubectl apply -f canary/cm.yaml
+kubectl apply -f canary/pods.yaml
+kubectl apply -f canary/ingress.yaml
+kubectl apply -f canary/services.yaml

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+    spec:
+      initContainers:
+        - name: init
+          image: registry.hub.docker.com/library/busybox:1.31.1
+          command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+          volumeMounts:
+          - name: app
+            mountPath: /app
+      containers:
+        - name: web
+          image: registry.hub.docker.com/xom4ek/web:kubernetes-intro
+          resources: {}
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8000
+          livenessProbe:
+            tcpSocket:
+              port: 8000
+          volumeMounts:
+          - name: app
+            mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: web-svc
+          servicePort: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-security/README.md
+++ b/kubernetes-security/README.md
@@ -1,0 +1,52 @@
+# xom4ek_platform
+xom4ek Platform repository
+
+# Выполнено ДЗ №1
+
+ - [x] Основное ДЗ
+
+## В процессе сделано:
+
+##### task01
+- Cоздан Service Account bob, Выдана ему роль admin в рамках всего кластера
+- Cоздан Service Account dave без доступа к кластеру
+
+###### taks02
+- Cоздан Namespace prometheus
+- Cоздан Service Account carol в этом Namespace
+- Выдана всем Service Account в Namespace prometheus возможность делать get, list, watch в отношении Pods всего кластера
+
+###### task03
+- Cоздан Namespace dev
+- Cоздан Service Account jane в Namespace dev
+- Выдана jane роль admin в рамках Namespace dev
+- Cоздан Service Account ken в Namespace dev
+- Выдана ken роль view в рамках Namespace dev
+
+## Как запустить проект:
+ - Запустить команду
+ ```shell
+ git clone https://github.com/otus-kuber-2020-04/xom4ek_platform.git && \
+ cd xom4ek_platform && \
+ git checkout kubernetes-security && \
+ kubectl create -f kubernetes-security/task01/task.yaml && \
+ kubectl create -f kubernetes-security/task02/task.yaml && \
+ kubectl create -f kubernetes-security/task03/task.yaml && \
+ ```
+
+## Как проверить работоспособность:
+
+ - Выполнить команды:
+  ```shell
+  # task01
+  kubectl auth can-i --list --namespace=kube-system --as=system:serviceaccount:default:dave
+  kubectl auth can-i --list --namespace=default --as=system:serviceaccount:default:dave
+  # task02
+  kubectl auth can-i --list --namespace=prometheus --as=system:serviceaccount:prometheus:carol
+  # task03
+  kubectl auth can-i --list --namespace=dev --as=system:serviceaccount:dev:jane
+  kubectl auth can-i --list --namespace=dev --as=system:serviceaccount:dev:ken
+  ```
+
+## PR checklist:
+ - [x] Выставлен label с темой домашнего задания

--- a/kubernetes-security/task01/task.yaml
+++ b/kubernetes-security/task01/task.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bob
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: bob
+subjects:
+  - kind: ServiceAccount
+    name: bob
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dave
+  namespace: default

--- a/kubernetes-security/task02/task.yaml
+++ b/kubernetes-security/task02/task.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prometheus
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: carol
+  namespace: prometheus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: task02
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: task02
+subjects:
+  - kind: Group
+    name: system:serviceaccounts:prometheus
+    namespace: prometheus
+roleRef:
+  kind: ClusterRole
+  name: task02
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-security/task03/task.yaml
+++ b/kubernetes-security/task03/task.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jane
+  namespace: dev
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jane
+  namespace: dev
+subjects:
+  - kind: ServiceAccount
+    name: jane
+    namespace: dev
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ken
+  namespace: dev
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ken
+  namespace: dev
+subjects:
+  - kind: ServiceAccount
+    name: ken
+    namespace: dev
+roleRef:
+  kind: ClusterRole
+  name: view
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
# xom4ek_platform
xom4ek Platform repository

# Выполнено ДЗ №4

- [x] Основное ДЗ
- [x] Задание со *

## В процессе сделано:

- #### Добавлены и изучены механизмы liveness и readiness probe

 Дополнительно они описанны по [ссылке](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)

  ```yaml
  readinessProbe:
    httpGet:
      path: /index.html
      port: 8000
  livenessProbe:
    tcpSocket:
      port: 8000
  ```

- #### Создали несколько [типов services](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)

  - [LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer)
  - [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport)
  - [ClusterIP](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
  - [ExternalName](https://kubernetes.io/docs/concepts/services-networking/service/#externalname)

  Дополнительно про endpoints можно почитать [тут](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/)

- #### Установлен MetalLB / Ingress / законфигурирован minikube длля использования IPVS
  - Настройка использования [IPVS]()
  ```sh

  ### move strictARP to true and mode to IPVS
  kubectl get configmap kube-proxy -n kube-system -o yaml | \
  sed -e 's/strictARP: false/strictARP: true/' | \
  sed -e 's/mode: ""/mode: "ipvs"/' | \
  kubectl apply -f - -n kube-system

  ### recreate pods kube-proxy
  kubectl --namespace kube-system delete pod --selector='k8s-app=kube-proxy'
  ```

  - Установка [MetalLB](https://metallb.universe.tf/installation/)
  ```sh
  export VERSION_MLB=v0.9.3
  kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/$VERSION_MLB/manifests/namespace.yaml
  kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/$VERSION_MLB/manifests/metallb.yaml
  # On first install only
  kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
  ```
  - Установка [Nginx-ingress](https://kubernetes.github.io/ingress-nginx/deploy/#bare-metal)
  ```sh
  kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/baremetal/deploy.yaml
  ```

- #### :star: Сделан сервис LoadBalancer , который откроет доступ к CoreDNS снаружи кластера

    Использование разных протоколов в одном service с типом [LoadBalancing запрещено](https://github.com/kubernetes/kubernetes/issues/23880) пока не реализовано, поэтому не получится использовать один service.
    Необходимо использовать annotation MetalLB [metallb.universe.tf/allow-shared-ip](https://metallb.universe.tf/usage/#ip-address-sharing), что позволит двум Service с разными протоколами маршрутизироваться по одному внешнему IP.

- #### Создан service с внешним IP выданным MetalLB для использования под ingress +  headless сервис

  Service для Ingress
  ```yaml
  spec:
    externalTrafficPolicy: Local
    type: LoadBalancer
    selector:
      app.kubernetes.io/name: ingress-nginx
  ```

  Headless
  ```yaml
  type: ClusterIP
  clusterIP: None
  ```

  Ну и пример правила для ingress

  ```yaml
  spec:
    rules:
    - http:
        paths:
        - path: /web
          backend:
            serviceName: web-svc
            servicePort: 8000
  ```

  Дополнительно про spec можно почитать [тут](https://kubernetes.github.io/ingress-nginx/user-guide/basic-usage/)

- #### :star: Создан ingress для kubernetes dashobard для доступа за /dashbaord

    Были использованы стандартные [аннотации nginx-ingress](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/):
    - [nginx.ingress.kubernetes.io/rewrite-target](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#rewrite)
    - [nginx.ingress.kubernetes.io/backend-protocol](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#backend-protocol)
    - [nginx.ingress.kubernetes.io/permanent-redirect](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#permanent-redirect)

  Важный кусок
  ```yaml
  annotations:
    nginx.ingress.kubernetes.io/rewrite-target: /$1
  ...
  - path: /dashboard/(.*)
  ```

  B для того чтобы работало dashboard без /
  ```yaml
  annotations:
    nginx.ingress.kubernetes.io/permanent-redirect: /dashboard/
  ...
  - path: /dashboard$
  ```

- #### :star: Создан ingress с конфигурацией под канареечное развертывание
  Общее описание Canary для ingress-nginx [тут](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#canary)
  Использовались anotations:
  - nginx.ingress.kubernetes.io/canary
  - nginx.ingress.kubernetes.io/canary-by-header
  - nginx.ingress.kubernetes.io/canary-by-header-value

  > Без конкретного hostname в ingress ничего не работало, хочется понять почему.

## Как запустить проект:
 ```shell
git clone https://github.com/otus-kuber-2020-04/xom4ek_platform.git && \
cd xom4ek_platform && \
git checkout kubernetes-networks && \
cd kubernetes-networks && prepare/install.sh
 ```

## Как проверить работоспособность:

- :star: coredns:

```shell
nslookup kubernetes.default.svc.cluster.local 172.17.255.10
```

- :star: ingress for Dashboard:

```shell
curl -L $(kubectl get svc ingress-nginx -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')/dashboard
```

- :star: canary ingress

```shell

curl -s --resolve example.com:80:kubectl get svc ingress-nginx -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}' example.com:80/canary | grep -v '>'

curl -s --resolve example.com:80:kubectl get svc ingress-nginx -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}' -H "canary:catch" example.com:80/canary | grep -v '>'
```

## PR checklist:
- [x] Выставлен label с темой домашнего задания
